### PR TITLE
Manual Serialize/Deserialize implementation for the App state

### DIFF
--- a/src/data_provider.rs
+++ b/src/data_provider.rs
@@ -1,4 +1,3 @@
-#[derive(serde::Serialize, serde::Deserialize)]
 pub struct FunctionProperty {
     pub raw_name: String,
     pub shallow_size_bytes: u32,
@@ -7,7 +6,6 @@ pub struct FunctionProperty {
     pub retained_size_percent: f32,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug)]
 pub struct FunctionPropertyDebugInfo {
     pub raw_name: String,
     pub demangled_name: Option<String>,

--- a/src/data_provider_twiggy.rs
+++ b/src/data_provider_twiggy.rs
@@ -5,13 +5,11 @@ use std::{ops::Range, path};
 use twiggy_opt::CommonCliOptions;
 use wasmparser::BinaryReader;
 
-#[derive(serde::Serialize, serde::Deserialize)]
 pub struct FunctionData {
     pub function_property: FunctionProperty,
     pub debug_info: FunctionPropertyDebugInfo,
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
 pub struct DataProviderTwiggy {
     raw_data: Vec<FunctionData>,
 
@@ -63,8 +61,6 @@ impl DataProviderTwiggy {
 
             let retained_size_bytes = items.retained_size(item.id());
             let retained_size_percent = (retained_size_bytes as f32 / total_size as f32) * 100.0;
-
-            let id_num = item.id().serializable();
 
             let range = item.bytes_range().clone();
             let mut locals = Vec::new();
@@ -244,12 +240,12 @@ impl FilterView for DataProviderTwiggy {
     fn get_total_percent(&self) -> f32 {
         self.total_percent
     }
-    
+
     fn get_locals_at(&self, idx: usize) -> &[String] {
         let original_idx = self.items_filtered[idx];
         &self.raw_data[original_idx].debug_info.locals
     }
-    
+
     fn get_ops_at(&self, idx: usize) -> &[String] {
         let original_idx = self.items_filtered[idx];
         &self.raw_data[original_idx].debug_info.function_ops

--- a/src/functions_explorer.rs
+++ b/src/functions_explorer.rs
@@ -1,4 +1,4 @@
-use crate::data_provider::{self, Filter, FilterView};
+use crate::data_provider::{Filter, FilterView};
 
 // This thing is used to explore the functions, sort by sizes and such things.
 #[derive(serde::Serialize, serde::Deserialize, Default)]


### PR DESCRIPTION
This is to optimise how the application state is being serialized/deserialized.

At the moment, the application is serializing the entire `DataProvider`, which includes all the state internally referenced by `DataProvider` implementations.

The new approach is for `FileEntry`, to serialize the file path and its type (currently only `Wasm`) and during the deserialization process, we re-create the `DataProvider` instance.

This is not only faster but it would load new changes (in case the wasm file actually changed).

Results: serialization went from `14s` to `0.1ms` on a sufficiently large wasm file.