### PR TITLE
Arena allocator and fast dominator view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,7 +255,9 @@ dependencies = [
  "egui-file-dialog",
  "egui_dock",
  "egui_extras",
+ "emath",
  "env_logger",
+ "libc",
  "serde",
  "twiggy-analyze",
  "twiggy-ir",
@@ -263,6 +265,7 @@ dependencies = [
  "twiggy-parser",
  "wasm-tools",
  "wasmparser 0.230.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ eframe = { version = "0.31", default-features = false, features = [
     "wayland",       # To support Linux (and CI)
     "x11",           # To support older Linux distributions (restores one of the default features)
 ] }
+emath = "0.31"
 env_logger = "0.11.8"
 serde = { version = "1.0.219", features = ["derive"] }
 twiggy-analyze = { git = "https://github.com/AlexEne/twiggy.git", branch = "wip-dissassembly", version = "0.7" }
@@ -30,6 +31,11 @@ wasm-tools = { version = "1.230.0", features = [
 ], default-features = false }
 addr2line = "0.24.2"
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2.172"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59", features = ["Win32_System_Memory"] }
 
 [profile.release]
 opt-level = 2

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,5 @@
 use crate::code_viewer::{CodeViewer, RowData};
-use crate::data_provider::{SourceCodeView, TopsView};
+use crate::data_provider::{FunctionsView, SourceCodeView};
 use crate::data_provider_twiggy::DataProviderTwiggy;
 use crate::functions_explorer::FunctionsExplorer;
 use egui_file_dialog::FileDialog;
@@ -29,11 +29,9 @@ impl egui_dock::TabViewer for TabViewer {
     }
 
     fn ui(&mut self, ui: &mut egui::Ui, tab: &mut Self::Tab) {
-        let mut selected_line = None;
         match &mut tab.contents {
             TabContent::SourceCodeViewer { code_viewer, .. } => {
                 code_viewer.show_code_as_table(ui);
-                selected_line = code_viewer.selected_row();
             }
 
             TabContent::AssemblyViewer { asm, .. } => {
@@ -149,7 +147,7 @@ impl TemplateApp {
     }
 
     fn show_src_folder_pick_window(&mut self, ctx: &egui::Context) {
-        egui::Window::new("Source code folders").show(ctx, |ui| {
+        egui::Window::new("Source code folders").show(ctx, |_| {
             self.file_dialog.pick_directory();
         });
     }

--- a/src/arena/array.rs
+++ b/src/arena/array.rs
@@ -1,0 +1,381 @@
+use std::{
+    ops::{Deref, DerefMut, Index, IndexMut},
+    ptr::{NonNull, slice_from_raw_parts_mut},
+    slice::{self, SliceIndex},
+};
+
+use super::Arena;
+
+/// A contiguous array type.
+pub struct Array<'a, T: Copy> {
+    #[allow(unused)]
+    arena: &'a Arena,
+
+    buf: NonNull<T>,
+    len: usize,
+    capacity: usize,
+}
+
+impl<'a, T: Copy> Array<'a, T> {
+    pub fn new(arena: &'a Arena, capacity: usize) -> Self {
+        Self {
+            arena,
+            buf: arena
+                .alloc_raw(
+                    std::mem::size_of::<T>() * capacity,
+                    std::mem::align_of::<T>(),
+                )
+                .cast(),
+            len: 0,
+            capacity,
+        }
+    }
+
+    /// Appends an element to the back of the array.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new length exceeds the array's capacity.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use binary_size_explorer::arena::Arena;
+    /// # use binary_size_explorer::arena::array::Array;
+    ///
+    /// let arena = Arena::new(1024);
+    /// let mut arr = Array::new(&arena, 4);
+    /// arr.push(1);
+    /// arr.push(2);
+    /// arr.push(3);
+    /// assert_eq!(arr.as_slice(), [1, 2, 3]);
+    /// ```
+    ///
+    /// # Time complexity
+    ///
+    /// Takes *O*(1) time.
+    #[inline]
+    #[track_caller]
+    pub fn push(&mut self, item: T) {
+        if self.len == self.capacity {
+            panic!("Not enough capacity");
+        }
+
+        unsafe { self.buf.add(self.len).write(item) };
+        self.len += 1;
+    }
+
+    /// Removes the last element from a array and returns it, or [`None`] if it
+    /// is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use binary_size_explorer::arena::Arena;
+    /// # use binary_size_explorer::arena::array::Array;
+    ///
+    /// let arena = Arena::new(1024);
+    /// let mut arr = Array::new(&arena, 4);
+    /// arr.extend_from_slice(&[1, 2, 3]);
+    /// assert_eq!(arr.pop(), Some(3));
+    /// assert_eq!(arr.as_slice(), [1, 2]);
+    /// ```
+    ///
+    /// # Time complexity
+    ///
+    /// Takes *O*(1) time.
+    #[inline]
+    pub fn pop(&mut self) -> Option<T> {
+        if self.len == 0 {
+            return None;
+        }
+
+        self.len -= 1;
+
+        Some(unsafe { *self.buf.add(self.len).as_ptr() })
+    }
+
+    /// Clones and appends all elements in a slice to the `Array`.
+    ///
+    /// This will effectivelly memcopy the arrays from `slice`
+    /// into the next available elements of this `Array`.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if there is not enough capacity
+    /// left in this `Array` to copy the entire slice.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use binary_size_explorer::arena::Arena;
+    /// # use binary_size_explorer::arena::array::Array;
+    ///
+    /// let arena = Arena::new(1024);
+    /// let mut arr = Array::new(&arena, 4);
+    /// arr.push(1);
+    /// arr.extend_from_slice(&[2, 3, 4]);
+    /// assert_eq!(arr.as_slice(), &[1, 2, 3, 4]);
+    /// ```
+    #[track_caller]
+    pub fn extend_from_slice(&mut self, slice: &[T]) {
+        if self.capacity - self.len < slice.len() {
+            panic!("Not enough capacity");
+        }
+
+        unsafe { &mut *slice_from_raw_parts_mut(self.buf.add(self.len).as_ptr(), slice.len()) }
+            .copy_from_slice(slice);
+
+        self.len += slice.len();
+    }
+
+    /// Clears the array, removing all values.
+    ///
+    /// Note that this method has no effect on the allocated capacity
+    /// of the array.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use binary_size_explorer::arena::Arena;
+    /// # use binary_size_explorer::arena::array::Array;
+    ///
+    /// let arena = Arena::new(1024);
+    /// let mut arr = Array::new(&arena, 4);
+    /// arr.extend_from_slice(&[1, 2, 3]);
+    ///
+    /// arr.clear();
+    ///
+    /// assert!(arr.is_empty());
+    /// ```
+    #[inline]
+    pub fn clear(&mut self) {
+        self.len = 0;
+    }
+
+    /// Returns the number of elements in the array, also referred to
+    /// as its 'length'.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use binary_size_explorer::arena::Arena;
+    /// # use binary_size_explorer::arena::array::Array;
+    ///
+    /// let arena = Arena::new(1024);
+    /// let mut arr = Array::new(&arena, 4);
+    /// arr.extend_from_slice(&[1, 2, 3]);
+    /// assert_eq!(arr.len(), 3);
+    /// ```
+    pub const fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns `true` if the array contains no elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use binary_size_explorer::arena::Arena;
+    /// # use binary_size_explorer::arena::array::Array;
+    ///
+    /// let arena = Arena::new(1024);
+    /// let mut arr = Array::new(&arena, 4);
+    /// assert!(arr.is_empty());
+    ///
+    /// arr.push(1);
+    /// assert!(!arr.is_empty());
+    /// ```
+    pub const fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Extracts a slice containing the entire array.
+    ///
+    /// Equivalent to `&s[..]`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use binary_size_explorer::arena::Arena;
+    /// # use binary_size_explorer::arena::array::Array;
+    ///
+    /// use std::io::{self, Write};
+    /// let arena = Arena::new(1024);
+    /// let buffer = Array::new(&arena, 4);
+    /// io::sink().write(buffer.as_slice()).unwrap();
+    /// ```
+    #[inline]
+    pub const fn as_slice(&self) -> &[T] {
+        // SAFETY: `slice::from_raw_parts` requires pointee is a contiguous, aligned buffer of size
+        // `len` containing properly-initialized `T`s. Data must not be mutated for the returned
+        // lifetime. Further, `len * mem::size_of::<T>` <= `ISIZE::MAX`, and allocation does not
+        // "wrap" through overflowing memory addresses.
+        //
+        // * Array API guarantees that self.buf:
+        //      * contains only properly-initialized items within 0..len
+        //      * is aligned, contiguous, and valid for `len` reads
+        //      * obeys size and address-wrapping constraints
+        //
+        // * We only construct `&mut` references to `self.buf` through `&mut self` methods; borrow-
+        //   check ensures that it is not possible to mutably alias `self.buf` within the
+        //   returned lifetime.
+        unsafe { slice::from_raw_parts(self.as_ptr(), self.len) }
+    }
+
+    /// Extracts a mutable slice of the entire array.
+    ///
+    /// Equivalent to `&mut s[..]`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use binary_size_explorer::arena::Arena;
+    /// # use binary_size_explorer::arena::array::Array;
+    ///
+    /// use std::io::{self, Read};
+    /// let arena = Arena::new(1024);
+    /// let mut buffer = Array::new(&arena, 4);
+    /// io::repeat(0b101).read_exact(buffer.as_mut_slice()).unwrap();
+    /// ```
+    #[inline]
+    pub const fn as_mut_slice(&mut self) -> &mut [T] {
+        // SAFETY: `slice::from_raw_parts_mut` requires pointee is a contiguous, aligned buffer of
+        // size `len` containing properly-initialized `T`s. Data must not be accessed through any
+        // other pointer for the returned lifetime. Further, `len * mem::size_of::<T>` <=
+        // `ISIZE::MAX` and allocation does not "wrap" through overflowing memory addresses.
+        //
+        // * Array API guarantees that self.buf:
+        //      * contains only properly-initialized items within 0..len
+        //      * is aligned, contiguous, and valid for `len` reads
+        //      * obeys size and address-wrapping constraints
+        //
+        // * We only construct references to `self.buf` through `&self` and `&mut self` methods;
+        //   borrow-check ensures that it is not possible to construct a reference to `self.buf`
+        //   within the returned lifetime.
+        unsafe { slice::from_raw_parts_mut(self.as_mut_ptr(), self.len) }
+    }
+
+    /// Returns a raw pointer to the array's buffer.
+    ///
+    /// The caller must ensure that the array outlives the pointer this
+    /// function returns, or else it will end up dangling.
+    ///
+    /// The caller must also ensure that the memory the pointer (non-transitively) points to
+    /// is never written to (except inside an `UnsafeCell`) using this pointer or any pointer
+    /// derived from it. If you need to mutate the contents of the slice, use [`as_mut_ptr`].
+    ///
+    /// This method guarantees that for the purpose of the aliasing model, this method
+    /// does not materialize a reference to the underlying slice, and thus the returned pointer
+    /// will remain valid when mixed with other calls to [`as_ptr`], [`as_mut_ptr`],
+    /// and [`as_non_null`].
+    ///
+    /// [`as_mut_ptr`]: Array::as_mut_ptr
+    /// [`as_ptr`]: Array::as_ptr
+    /// [`as_non_null`]: Array::as_non_null
+    #[inline]
+    pub const fn as_ptr(&self) -> *const T {
+        // We shadow the slice method of the same name to avoid going through
+        // `deref`, which creates an intermediate reference.
+        self.buf.as_ptr()
+    }
+
+    /// Returns a raw mutable pointer to the array's buffer.
+    ///
+    /// The caller must ensure that the array outlives the pointer this
+    /// function returns, or else it will end up dangling.
+    ///
+    /// This method guarantees that for the purpose of the aliasing model, this method
+    /// does not materialize a reference to the underlying slice, and thus the returned pointer
+    /// will remain valid when mixed with other calls to [`as_ptr`], [`as_mut_ptr`],
+    /// and [`as_non_null`].
+    ///
+    /// [`as_mut_ptr`]: Array::as_mut_ptr
+    /// [`as_ptr`]: Array::as_ptr
+    /// [`as_non_null`]: Array::as_non_null
+    #[inline]
+    pub const fn as_mut_ptr(&mut self) -> *mut T {
+        // We shadow the slice method of the same name to avoid going through
+        // `deref_mut`, which creates an intermediate reference.
+        self.buf.as_ptr()
+    }
+
+    /// Returns a `NonNull` pointer to the array's buffer.
+    ///
+    /// The caller must ensure that the array outlives the pointer this
+    /// function returns, or else it will end up dangling.
+    ///
+    /// This method guarantees that for the purpose of the aliasing model, this method
+    /// does not materialize a reference to the underlying slice, and thus the returned pointer
+    /// will remain valid when mixed with other calls to [`as_ptr`], [`as_mut_ptr`],
+    /// and [`as_non_null`].
+    ///
+    /// [`as_mut_ptr`]: Array::as_mut_ptr
+    /// [`as_ptr`]: Array::as_ptr
+    /// [`as_non_null`]: Array::as_non_null
+    #[inline]
+    pub fn as_non_null(&mut self) -> NonNull<T> {
+        self.buf
+    }
+}
+
+impl<'a, Idx, T: Copy> Index<Idx> for Array<'a, T>
+where
+    Idx: SliceIndex<[T]>,
+{
+    type Output = Idx::Output;
+
+    fn index(&self, index: Idx) -> &Self::Output {
+        &self.as_slice()[index]
+    }
+}
+
+impl<'a, Idx, T: Copy> IndexMut<Idx> for Array<'a, T>
+where
+    Idx: SliceIndex<[T]>,
+{
+    fn index_mut(&mut self, index: Idx) -> &mut Self::Output {
+        &mut self.as_mut_slice()[index]
+    }
+}
+
+impl<'a, T: Copy> Deref for Array<'a, T> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}
+
+impl<'a, T: Copy> DerefMut for Array<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.as_mut_slice()
+    }
+}
+
+impl<'a, T: Copy + PartialEq> PartialEq for Array<'a, T> {
+    fn eq(&self, other: &Self) -> bool {
+        if self.len != other.len {
+            return false;
+        }
+
+        for i in 0..self.len {
+            if self[i] != other[i] {
+                return false;
+            }
+        }
+        true
+    }
+}
+impl<'a, T: Copy + Eq> Eq for Array<'a, T> {}
+
+impl<'a> std::fmt::Write for Array<'a, u8> {
+    fn write_str(&mut self, s: &str) -> std::fmt::Result {
+        if (self.capacity - self.len) < s.len() {
+            return Err(std::fmt::Error);
+        }
+
+        self.extend_from_slice(s.as_bytes());
+        Ok(())
+    }
+}

--- a/src/arena/mod.rs
+++ b/src/arena/mod.rs
@@ -1,0 +1,237 @@
+use std::{cell::Cell, mem::MaybeUninit, ptr::NonNull};
+
+pub mod array;
+pub mod scratch;
+
+#[cfg(unix)]
+mod memory {
+    use libc;
+    use std::ptr::NonNull;
+
+    pub unsafe fn virtual_reserve(len: usize) -> NonNull<u8> {
+        unsafe {
+            let ptr = libc::mmap(
+                std::ptr::null_mut(),
+                len,
+                libc::PROT_NONE,
+                libc::MAP_ANONYMOUS | libc::MAP_PRIVATE,
+                -1,
+                0,
+            );
+
+            if !ptr.is_null() && !std::ptr::eq(ptr, libc::MAP_FAILED) {
+                NonNull::new_unchecked(ptr.cast())
+            } else {
+                panic!("Failed to reserve virtual memory");
+            }
+        }
+    }
+
+    pub unsafe fn virtual_commit(ptr: NonNull<u8>, len: usize) {
+        unsafe {
+            if libc::mprotect(ptr.as_ptr().cast(), len, libc::PROT_READ | libc::PROT_WRITE) != 0 {
+                panic!("Failed to commit virtual memory");
+            }
+        }
+    }
+
+    pub unsafe fn virtual_release(ptr: NonNull<u8>, len: usize) {
+        unsafe {
+            if libc::munmap(ptr.as_ptr().cast(), len) == -1 {
+                panic!("Failed to release virtual memory");
+            }
+        }
+    }
+}
+
+#[cfg(windows)]
+mod memory {
+    use std::ptr::NonNull;
+    use windows_sys::Win32::System::Memory::{
+        MEM_COMMIT, MEM_RELEASE, MEM_RESERVE, PAGE_READWRITE, VirtualAlloc, VirtualFree,
+    };
+
+    pub unsafe fn virtual_reserve(size: usize) -> NonNull<u8> {
+        unsafe {
+            let ptr = VirtualAlloc(std::ptr::null(), size, MEM_RESERVE, PAGE_READWRITE);
+
+            if !ptr.is_null() {
+                NonNull::new_unchecked(ptr.cast())
+            } else {
+                panic!("Failed to reserve virtual memory");
+            }
+        }
+    }
+
+    pub unsafe fn virtual_commit(ptr: NonNull<u8>, size: usize) {
+        unsafe {
+            VirtualAlloc(ptr.as_ptr().cast(), size, MEM_COMMIT, PAGE_READWRITE);
+        }
+    }
+
+    pub unsafe fn virtual_release(ptr: NonNull<u8>, _: usize) {
+        unsafe {
+            if VirtualFree(ptr.as_ptr().cast(), 0, MEM_RELEASE) == 0 {
+                panic!("Failed to release virtual memory");
+            }
+        }
+    }
+}
+
+const ALLOCATION_CHUNCK_SIZE: usize = 64 * 1024;
+
+macro_rules! assert_pow_of_2 {
+    ($len:expr) => {
+        assert!(($len & ($len - 1)) == 0)
+    };
+}
+
+/// Trait that can be implemented by any type `T` to signal
+/// that given a block of memory with aligment `std::mem::align_of::<T>`
+/// and size `std::mem::align_of::<T>`, that memory represents
+/// a valid object of type `T` regardless of which bytes
+/// are in there.
+pub unsafe trait AnyBits {}
+
+/// Trait that can be implemented by any type `T` to signal
+/// that given a block of zero bytes of memory with aligment
+/// `std::mem::align_of::<T>` and size `std::mem::align_of::<T>`,
+/// that memory represents a valid object of type `T`.
+pub unsafe trait ZeroBits {}
+
+/// An arena allocator.
+pub struct Arena {
+    buffer: NonNull<u8>,
+    capacity: usize,
+    offset: Cell<usize>,
+    commited: Cell<usize>,
+}
+
+impl Arena {
+    pub const fn empty() -> Self {
+        Self {
+            buffer: NonNull::dangling(),
+            capacity: 0,
+            offset: Cell::new(0),
+            commited: Cell::new(0),
+        }
+    }
+
+    pub fn new(capacity: usize) -> Self {
+        let capacity =
+            (usize::max(capacity, 1) + ALLOCATION_CHUNCK_SIZE - 1) & !(ALLOCATION_CHUNCK_SIZE - 1);
+
+        let buffer = unsafe { memory::virtual_reserve(capacity) };
+
+        Self {
+            buffer,
+            capacity,
+            commited: Cell::new(0),
+            offset: Cell::new(0),
+        }
+    }
+
+    /// Allocates a region of memory with the alignment and size
+    /// of type `T`.
+    ///
+    /// The memory is not initialised and it's up
+    /// to the caller to initialise the returned block of memory
+    /// before using it.
+    pub fn alloc_unint<T>(&self) -> &mut MaybeUninit<T> {
+        let size = std::mem::size_of::<MaybeUninit<T>>();
+        let align = std::mem::align_of::<MaybeUninit<T>>();
+
+        let ptr = self.alloc_raw(size, align).as_ptr();
+
+        unsafe { &mut *ptr.cast() }
+    }
+
+    /// Allocates a region of memory with the alignment and size
+    /// of type `T`.
+    ///
+    /// The memory is not initialised and it's up
+    /// to the caller to initialise the returned block of memory
+    /// before using it.
+    pub fn alloc_new<T: AnyBits>(&self) -> &mut T {
+        let size = std::mem::size_of::<T>();
+        let align = std::mem::align_of::<T>();
+
+        let ptr = self.alloc_raw(size, align).as_ptr();
+
+        unsafe { &mut *ptr.cast() }
+    }
+
+    /// Allocates a region of memory with the alignment and size
+    /// of type `T`.
+    ///
+    /// The memory is guaranteed to contain only zero bytes.
+    pub fn alloc_zeroed<T: ZeroBits>(&self) -> &mut T {
+        let size = std::mem::size_of::<MaybeUninit<T>>();
+        let align = std::mem::align_of::<MaybeUninit<T>>();
+
+        let ptr = self.alloc_raw(size, align).as_ptr();
+        unsafe {
+            std::ptr::write_bytes(ptr, 0, size);
+        }
+
+        unsafe { &mut *ptr.cast() }
+    }
+
+    fn alloc_raw(&self, size: usize, align: usize) -> NonNull<u8> {
+        assert_pow_of_2!(align);
+
+        let mut start = self.offset.get();
+        let module = start & (align - 1);
+        if module > 0 {
+            start += align - module;
+        }
+        let end = start + size;
+
+        if end > self.commited.get() {
+            let new_commited = (end + ALLOCATION_CHUNCK_SIZE - 1) & !(ALLOCATION_CHUNCK_SIZE - 1);
+
+            if new_commited > self.capacity {
+                panic!("Failed to allocate from Arena: not enough capacity");
+            }
+
+            unsafe {
+                memory::virtual_commit(
+                    self.buffer.add(self.commited.get()),
+                    new_commited - self.commited.get(),
+                );
+            }
+            self.commited.set(new_commited);
+        }
+
+        self.offset.set(end);
+        unsafe { self.buffer.add(start) }
+    }
+
+    /// The offset of the arena represents the number of bytes
+    /// reserved by allocations so far.
+    pub(super) fn offset(&self) -> usize {
+        self.offset.get()
+    }
+
+    /// Resets the `offset` of the arena, effectivelly "freeing"
+    /// all previous allocations.
+    ///
+    /// It's the callee responsability to ensure that no allocations
+    /// (i.e., mutable references) returned by this arena still exists.
+    ///
+    /// This call will not actually free memory. So dangling pointers
+    /// can still point to accessible memory, so be careful!!.
+    pub(super) unsafe fn reset(&self, offset: usize) {
+        self.offset.set(offset);
+    }
+}
+
+impl Drop for Arena {
+    fn drop(&mut self) {
+        unsafe {
+            if self.buffer != NonNull::dangling() {
+                memory::virtual_release(self.buffer, self.capacity);
+            }
+        }
+    }
+}

--- a/src/arena/scratch.rs
+++ b/src/arena/scratch.rs
@@ -1,0 +1,49 @@
+use std::{ops::Deref, ptr::NonNull};
+
+use super::Arena;
+
+static mut SCRATCH_ARENAS: [Arena; 2] = [Arena::empty(), Arena::empty()];
+
+pub struct ScratchArena<'s> {
+    arena: &'s Arena,
+    offset: usize,
+}
+
+impl Drop for ScratchArena<'_> {
+    fn drop(&mut self) {
+        unsafe {
+            self.arena.reset(self.offset);
+        }
+    }
+}
+
+impl Deref for ScratchArena<'_> {
+    type Target = Arena;
+
+    fn deref(&self) -> &Self::Target {
+        &self.arena
+    }
+}
+
+pub fn scratch_arena(arenas: &[Arena]) -> ScratchArena<'_> {
+    unsafe {
+        for sa in &mut SCRATCH_ARENAS[..] {
+            if sa.buffer == NonNull::dangling() {
+                *sa = Arena::new(2 * 1024 * 1024);
+            }
+
+            for arena in arenas {
+                if sa.buffer == arena.buffer {
+                    break;
+                }
+            }
+
+            return ScratchArena {
+                arena: sa,
+                offset: sa.offset(),
+            };
+        }
+    }
+
+    panic!("Not possible to allocated scratch arena")
+}

--- a/src/data_provider.rs
+++ b/src/data_provider.rs
@@ -8,6 +8,16 @@ pub struct FunctionProperty {
     pub retained_size_percent: f32,
 }
 
+impl FunctionProperty {
+    pub fn name(&self) -> &str {
+        if let Some(demangled_name) = self.demangled_name.as_ref() {
+            demangled_name
+        } else {
+            &self.raw_name
+        }
+    }
+}
+
 pub struct FunctionPropertyDebugInfo {
     pub locals: Vec<String>,
     pub function_ops: Vec<FunctionOp>,
@@ -34,11 +44,15 @@ pub enum ViewMode {
     Dominators,
 }
 
-pub trait FunctionsView: TopsView + DominatorsView {
+pub trait FunctionsView {
     fn set_view_mode(&mut self, view_mode: ViewMode);
     fn set_filter(&mut self, filter: Filter);
     fn get_total_size(&self) -> u32;
     fn get_total_percent(&self) -> f32;
+
+    fn get_locals_at(&self, idx: usize) -> &[String];
+    fn get_ops_at(&self, idx: usize) -> &[FunctionOp];
+    fn get_start_addr(&self, idx: usize) -> u64;
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -56,24 +70,6 @@ impl Filter {
             name: name.into().to_lowercase(),
         }
     }
-}
-
-pub trait TopsView {
-    fn get_tops_items_count(&self) -> usize;
-    fn get_tops_item_at(&self, idx: usize) -> &FunctionProperty;
-
-    fn get_locals_at(&self, idx: usize) -> &[String];
-    fn get_ops_at(&self, idx: usize) -> &[FunctionOp];
-    fn get_start_addr(&self, idx: usize) -> u64;
-}
-
-pub trait DominatorsView {
-    fn get_roots(&self) -> &Vec<usize>;
-    fn get_dominator_item_at(&self, idx: usize) -> &FunctionProperty;
-    fn get_children_of(&self, idx: usize) -> &Vec<usize>;
-    fn is_child_visible(&self, idx: usize) -> bool;
-    fn set_child_open(&mut self, idx: usize, open: bool);
-    fn is_child_open(&self, idx: usize) -> bool;
 }
 
 #[derive(Debug)]

--- a/src/functions_explorer.rs
+++ b/src/functions_explorer.rs
@@ -1,6 +1,14 @@
-use egui::{CollapsingHeader, ComboBox, Vec2b};
+use egui::{
+    Color32, ComboBox, Id, Rect, Response, Sense, Shape, TextStyle, TextWrapMode, WidgetText,
+    epaint::RectShape, pos2, vec2,
+};
 
-use crate::data_provider::{DominatorsView, Filter, FunctionsView, ViewMode};
+use crate::{
+    arena::{Arena, array::Array, scratch::scratch_arena},
+    data_provider::{Filter, FunctionsView, ViewMode},
+    data_provider_twiggy::DataProviderTwiggy,
+    gui::tree_view::TreeView,
+};
 use core::str;
 
 #[derive(Clone, Copy, Default, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -25,7 +33,7 @@ impl FunctionsExplorer {
     pub fn show_functions_table(
         &mut self,
         ui: &mut egui::Ui,
-        functions_view: &mut dyn FunctionsView,
+        functions_data: &mut DataProviderTwiggy,
     ) {
         ComboBox::from_label("Mode")
             .selected_text(format!("{:?}", self.mode))
@@ -34,7 +42,7 @@ impl FunctionsExplorer {
                 ui.selectable_value(&mut self.mode, ViewMode::Dominators, "Dominators");
             });
 
-        functions_view.set_view_mode(self.mode);
+        functions_data.set_view_mode(self.mode);
 
         use egui_extras::{Size, StripBuilder};
         egui::ScrollArea::vertical().show(ui, |ui| {
@@ -45,8 +53,8 @@ impl FunctionsExplorer {
                     strip.cell(|ui| {
                         // Render actual view
                         match self.mode {
-                            ViewMode::Tops => self.show_tops(ui, functions_view),
-                            ViewMode::Dominators => self.show_dominators(ui, functions_view),
+                            ViewMode::Tops => self.show_tops(ui, functions_data),
+                            ViewMode::Dominators => self.show_dominators(ui, functions_data),
                         }
                     });
                     strip.cell(|ui| {
@@ -58,10 +66,10 @@ impl FunctionsExplorer {
                                 if ui.text_edit_singleline(&mut self.filter_text).changed() {
                                     self.selected_row = None; // Reset selected row.
                                     if !self.filter_text.is_empty() {
-                                        functions_view
+                                        functions_data
                                             .set_filter(Filter::name_filter(&self.filter_text));
                                     } else {
-                                        functions_view.set_filter(Filter::All);
+                                        functions_data.set_filter(Filter::All);
                                     }
                                 }
                             });
@@ -73,15 +81,15 @@ impl FunctionsExplorer {
                             if self.mode == ViewMode::Tops {
                                 ui.label(format!(
                                     "Total count: {} Total size (MB): {:.2}, Total %: {:.4?}%",
-                                    functions_view.get_tops_items_count(),
-                                    functions_view.get_total_size() as f32 / (1024.0 * 1024.0),
-                                    functions_view.get_total_percent(),
+                                    functions_data.top_view_items_filtered.len(),
+                                    functions_data.get_total_size() as f32 / (1024.0 * 1024.0),
+                                    functions_data.get_total_percent(),
                                 ));
                             } else {
                                 ui.label(format!(
                                     "Total size (MB): {:.2}, Total %: {:.4?}%",
-                                    functions_view.get_total_size() as f32 / (1024.0 * 1024.0),
-                                    functions_view.get_total_percent(),
+                                    functions_data.get_total_size() as f32 / (1024.0 * 1024.0),
+                                    functions_data.get_total_percent(),
                                 ));
                             }
                         });
@@ -90,15 +98,9 @@ impl FunctionsExplorer {
         });
     }
 
-    fn show_tops(&mut self, ui: &mut egui::Ui, filtered_view: &mut dyn FunctionsView) {
-        let table_rows_count = filtered_view.get_tops_items_count();
-        // use egui_extras::{Size, StripBuilder};
+    fn show_tops(&mut self, ui: &mut egui::Ui, filtered_view: &mut DataProviderTwiggy) {
+        let table_rows_count = filtered_view.top_view_items_filtered.len();
         egui::ScrollArea::vertical().show(ui, |ui| {
-            //     StripBuilder::new(ui)
-            //         .size(Size::remainder().at_least(100.0)) // for the table
-            //         .size(Size::exact(120.0))
-            //         .vertical(|mut strip| {
-            //             strip.cell(|ui| {
             let old_selectable_labels = ui.style().interaction.selectable_labels;
             ui.style_mut().interaction.selectable_labels = false;
             egui::ScrollArea::horizontal().show(ui, |ui| {
@@ -162,11 +164,14 @@ impl FunctionsExplorer {
                                 row.index()
                             };
 
+                            let symbol_index = filtered_view.top_view_items_filtered[row_index];
+
                             if let Some(selected_row) = self.selected_row {
-                                row.set_selected(row_index == selected_row);
+                                row.set_selected(symbol_index == selected_row);
                             }
 
-                            let filtered_item = filtered_view.get_tops_item_at(row_index);
+                            let filtered_item =
+                                &filtered_view.raw_data[symbol_index].function_property;
 
                             row.col(|ui| {
                                 ui.label_memory(filtered_item.retained_size_bytes);
@@ -198,124 +203,141 @@ impl FunctionsExplorer {
                             });
 
                             if row.response().clicked() {
-                                self.selected_row = Some(row_index);
+                                self.selected_row = Some(symbol_index);
                             }
                         });
                     });
             });
             ui.style_mut().interaction.selectable_labels = old_selectable_labels;
-            //             });
-            //             strip.cell(|ui| {
-            //                 ui.vertical(|ui| {
-            //                     ui.separator();
-
-            //                     ui.horizontal(|ui| {
-            //                         ui.label("Filter: ");
-            //                         if ui.text_edit_singleline(&mut self.filter_text).changed() {
-            //                             self.selected_row = None; // Reset selected row.
-            //                             if !self.filter_text.is_empty() {
-            //                                 filtered_view
-            //                                     .set_filter(Filter::name_filter(&self.filter_text));
-            //                             } else {
-            //                                 filtered_view.set_filter(Filter::All);
-            //                             }
-            //                         }
-            //                     });
-
-            //                     ui.separator();
-
-            //                     ui.label("Stats");
-            //                     ui.label(format!(
-            //                         "Total count: {} Total size (MB): {:.2}, Total %: {:.4?}%",
-            //                         filtered_view.get_tops_items_count(),
-            //                         filtered_view.get_total_size() as f32 / (1024.0 * 1024.0),
-            //                         filtered_view.get_total_percent(),
-            //                     ));
-            //                 });
-            //             });
         });
-        // });
     }
 
-    fn show_dominators(&mut self, ui: &mut egui::Ui, dominator_view: &mut dyn FunctionsView) {
-        // use egui_extras::{Size, StripBuilder};
+    fn show_dominators(&mut self, ui: &mut egui::Ui, dominator_view: &mut DataProviderTwiggy) {
+        let raw_data = &dominator_view.raw_data;
+        let state = &mut dominator_view.dominator_view_tree_state;
 
-        // StripBuilder::new(ui)
-        //     .size(Size::remainder().at_least(100.0)) // for the table
-        //     .size(Size::exact(120.0))
-        //     .vertical(|mut strip| {
-        //         strip.cell(|ui| {
-        egui::ScrollArea::both()
-            .auto_shrink(Vec2b::new(false, true))
-            .show(ui, |ui| {
-                fn render_item(
-                    ui: &mut egui::Ui,
-                    dominator_view: &mut dyn DominatorsView,
-                    index: usize,
-                ) {
-                    let item = dominator_view.get_dominator_item_at(index);
-                    let visible = dominator_view.is_child_visible(index);
-                    let open = dominator_view.is_child_open(index);
+        TreeView.body(ui, state, 20.0, |ui, item| {
+            if item.selected {
+                self.selected_row = Some(item.index);
+            }
 
-                    if !visible {
-                        return;
-                    }
+            let function_properties = &raw_data[item.index].function_property;
+            let name = function_properties.name();
+            let retained_size_percent = function_properties.retained_size_percent;
 
-                    let children = dominator_view.get_children_of(index).clone();
+            let available = ui.available_rect_before_wrap();
 
-                    let name = format!(
-                        "{:.2}: {} - {}",
-                        item.retained_size_percent,
-                        item.retained_size_bytes,
-                        item.demangled_name.clone().unwrap_or_default()
-                    );
+            const PERCENTAGE_WIDTH: f32 = 50.0;
+            const PERCENTAGE_BAR_HEIGHT: f32 = 2.0;
 
-                    let response = CollapsingHeader::new(name).open(Some(open)).show(ui, |ui| {
-                        for child in children {
-                            render_item(ui, dominator_view, child);
-                        }
-                    });
+            let percentage_text_pos = available.min;
+            let percentage_text: WidgetText = format!("{:.2}%", retained_size_percent).into();
+            let percentage_galley = percentage_text.into_galley(
+                ui,
+                Some(TextWrapMode::Extend),
+                PERCENTAGE_WIDTH,
+                TextStyle::Button,
+            );
 
-                    if response.header_response.clicked() {
-                        dominator_view.set_child_open(index, !open);
-                    }
-                }
+            let text_pos = available.min + vec2(PERCENTAGE_WIDTH, 0.0);
+            let wrap_width = available.right() - text_pos.x;
 
-                let roots = dominator_view.get_roots().clone();
-                for root in roots {
-                    render_item(ui, dominator_view, root);
-                }
-            });
-        //     });
-        //     strip.cell(|ui| {
-        //         ui.vertical(|ui| {
-        //             ui.separator();
+            // TODO: build galley from scratch?
+            let text: WidgetText = name.into();
+            let symbol_galley = text.into_galley(
+                ui,
+                Some(TextWrapMode::Extend),
+                wrap_width,
+                TextStyle::Button,
+            );
 
-        //             ui.horizontal(|ui| {
-        //                 ui.label("Filter: ");
-        //                 if ui.text_edit_singleline(&mut self.filter_text).changed() {
-        //                     self.selected_row = None; // Reset selected row.
-        //                     if !self.filter_text.is_empty() {
-        //                         dominator_view
-        //                             .set_filter(Filter::name_filter(&self.filter_text));
-        //                     } else {
-        //                         dominator_view.set_filter(Filter::All);
-        //                     }
-        //                 }
-        //             });
+            let button_padding = ui.spacing().button_padding;
+            let text_max_x = text_pos.x + symbol_galley.size().x;
+            let desired_width = text_max_x + button_padding.x - available.left();
+            let desired_size = vec2(
+                desired_width,
+                symbol_galley.size().y + 2.0 * button_padding.y + 2.0 * PERCENTAGE_BAR_HEIGHT,
+            );
 
-        //             ui.separator();
+            let (_, rect) = ui.allocate_space(desired_size);
 
-        //             ui.label("Stats");
-        //             ui.label(format!(
-        //                 "Total size (MB): {:.2}, Total %: {:.4?}%",
-        //                 // dominator_view.get_filtered_items_count(),
-        //                 dominator_view.get_total_size() as f32 / (1024.0 * 1024.0),
-        //                 dominator_view.get_total_percent(),
-        //             ));
-        //         });
-        //     });
-        // });
+            // Center text element on the vertical axis
+            let percentage_text_pos = pos2(
+                percentage_text_pos.x,
+                available.center().y - percentage_galley.size().y / 2.0,
+            );
+            let symbol_text_pos = pos2(
+                text_pos.x,
+                available.center().y - symbol_galley.size().y / 2.0,
+            );
+
+            let percentage_response = ui.interact(
+                Rect {
+                    min: percentage_text_pos,
+                    max: percentage_text_pos + percentage_galley.size(),
+                },
+                Id::new(name),
+                Sense::hover(),
+            );
+
+            let visuals = ui
+                .style()
+                .interact_selectable(&item.response, item.selected);
+
+            // Percentage label
+            ui.painter()
+                .galley(percentage_text_pos, percentage_galley, visuals.text_color());
+            ui.painter().add(Shape::Rect(RectShape::filled(
+                Rect {
+                    min: pos2(
+                        percentage_text_pos.x,
+                        rect.min.y + rect.height() - PERCENTAGE_BAR_HEIGHT,
+                    ),
+                    max: pos2(
+                        percentage_text_pos.x + (retained_size_percent / 100.0) * PERCENTAGE_WIDTH,
+                        rect.min.y + rect.height(),
+                    ),
+                },
+                0.0,
+                Color32::GREEN,
+            )));
+
+            // Percentage tooltip
+            if percentage_response.hovered() {
+                let scratch = scratch_arena(&[]);
+                let mut buffer: Array<'_, u8> = Array::new(&scratch, 1024);
+
+                // TODO: (bruno) probably should just use auto-layout here
+                use std::fmt::Write;
+                _ = writeln!(
+                    &mut buffer,
+                    "Retained size: {:5.2}(MB)",
+                    function_properties.retained_size_bytes as f32 / (1024.0 * 1024.0)
+                );
+                _ = writeln!(
+                    &mut buffer,
+                    "Self size: {:9.2}(MB)",
+                    function_properties.shallow_size_bytes as f32 / (1024.0 * 1024.0)
+                );
+                _ = writeln!(
+                    &mut buffer,
+                    "Retained: {:10.2} (%)",
+                    function_properties.retained_size_percent
+                );
+                _ = write!(
+                    &mut buffer,
+                    "Self: {:14.2} (%)",
+                    function_properties.shallow_size_percent
+                );
+                percentage_response.show_tooltip_ui(|ui| {
+                    ui.monospace(std::str::from_utf8(&buffer).unwrap());
+                });
+            }
+
+            // Symbol label
+            ui.painter()
+                .galley(symbol_text_pos, symbol_galley, visuals.text_color());
+        });
     }
 }
 

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1,0 +1,1 @@
+pub mod tree_view;

--- a/src/gui/tree_view.rs
+++ b/src/gui/tree_view.rs
@@ -1,0 +1,226 @@
+use egui::{Id, Rect, Response, Sense, Ui, UiBuilder, pos2, scroll_area::ScrollAreaOutput, vec2};
+
+pub struct TreeItemState {
+    pub parent: usize,
+    pub index: usize,
+    pub descendants_count: usize,
+    pub force_opened: bool,
+    pub opened: bool,
+    pub visible: bool,
+    pub indent: u8,
+}
+
+pub struct TreeState {
+    pub nodes: Vec<TreeItemState>,
+    pub indices: Vec<usize>,
+
+    pub hovered_index: usize,
+    pub selected_index: usize,
+}
+
+impl TreeState {
+    pub fn new(mut nodes: Vec<TreeItemState>) -> Self {
+        let indices = Vec::with_capacity(nodes.len());
+
+        if !nodes.is_empty() {
+            nodes[0].opened = true;
+        }
+
+        let mut result = Self {
+            nodes,
+            indices,
+            hovered_index: usize::MAX,
+            selected_index: usize::MAX,
+        };
+
+        result.recompute_indices();
+        result
+    }
+
+    #[inline(always)]
+    pub fn node_at(&self, pos: usize) -> &TreeItemState {
+        &self.nodes[self.indices[pos]]
+    }
+
+    #[inline(always)]
+    pub fn node_at_mut(&mut self, pos: usize) -> &mut TreeItemState {
+        &mut self.nodes[self.indices[pos]]
+    }
+
+    pub(crate) fn recompute_indices(&mut self) {
+        let mut node_index = 0;
+
+        self.indices.clear();
+
+        while node_index < self.nodes.len() {
+            if self.nodes[node_index].visible {
+                self.indices.push(node_index);
+
+                if self.nodes[node_index].parent != 0 {
+                    self.nodes[node_index].indent =
+                        self.nodes[self.nodes[node_index].parent].indent + 1;
+                } else {
+                    self.nodes[node_index].indent = 0;
+                }
+            }
+            // If children are not visible, skip all the descendants
+            if !self.nodes[node_index].opened && !self.nodes[node_index].force_opened {
+                node_index += self.nodes[node_index].descendants_count;
+            }
+
+            node_index += 1;
+        }
+    }
+}
+
+pub struct TreeItem<'a> {
+    pub index: usize,
+    pub selected: bool,
+    pub response: &'a Response,
+}
+
+pub struct TreeView;
+
+impl TreeView {
+    pub fn body(
+        &mut self,
+        ui: &mut Ui,
+        state: &mut TreeState,
+        row_height_sans_spacing: f32,
+        mut add_item: impl FnMut(&mut Ui, TreeItem<'_>),
+    ) -> ScrollAreaOutput<()> {
+        let items_count = state.indices.len() - 1;
+        let available_height = ui.available_height();
+        let available_width = ui.available_width();
+
+        let mut table = egui_extras::TableBuilder::new(ui)
+            .striped(true)
+            .resizable(true)
+            .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
+            .column(egui_extras::Column::exact(available_width))
+            .min_scrolled_height(0.0)
+            .max_scroll_height(available_height);
+
+        // Prepare it so it is clickable and we see when we hover rows.
+        table = table.sense(egui::Sense::click());
+
+        let mut item_state_changed = false;
+
+        let scroll_area_output = table
+            .header(20.0, |mut header| {
+                header.col(|ui| {
+                    ui.strong("Name");
+                });
+            })
+            .body(|body| {
+                body.rows(18.0, items_count, |mut row| {
+                    let item_index = row.index() + 1;
+
+                    row.set_hovered(state.hovered_index == item_index);
+                    row.set_selected(state.selected_index == item_index);
+
+                    row.col(|ui| {
+                        let id = Id::new(state.node_at(item_index).index);
+                        let id = ui.make_persistent_id(id);
+
+                        let available = ui.available_rect_before_wrap();
+                        let (_, mut rect) =
+                            ui.allocate_space(vec2(available.width(), row_height_sans_spacing));
+
+                        let header_response = ui.interact(rect, id, Sense::click());
+
+                        if header_response.clicked() {
+                            let node = state.node_at_mut(item_index);
+                            node.opened = !node.opened;
+
+                            // If node was explicitely closed, disabled force opened
+                            if node.opened == false {
+                                node.force_opened = false;
+                            }
+
+                            state.selected_index = item_index;
+
+                            item_state_changed = true;
+                        }
+
+                        if header_response.hovered() {
+                            state.hovered_index = item_index;
+                        }
+
+                        let openness = if state.node_at(item_index).opened
+                            || state.node_at(item_index).force_opened
+                        {
+                            1.0
+                        } else {
+                            0.0
+                        };
+
+                        // Indent the rect before rendering icon and content
+                        let indent = 32.0 * state.node_at(item_index).indent as f32;
+                        rect.min.x += indent;
+
+                        let (mut icon_rect, _) = ui.spacing().icon_rectangles(rect);
+                        icon_rect.set_center(pos2(
+                            rect.left() + ui.spacing().indent / 2.0,
+                            rect.center().y,
+                        ));
+                        let icon_response = header_response.clone().with_new_rect(icon_rect);
+                        paint_tree_icon(
+                            ui,
+                            openness,
+                            state.node_at(item_index).descendants_count > 0,
+                            &icon_response,
+                        );
+
+                        // Indent the rect by the space used by the icon
+                        rect.min.x += ui.spacing().indent;
+                        let mut child_ui =
+                            ui.new_child(UiBuilder::new().id_salt(id).max_rect(rect));
+                        add_item(
+                            &mut child_ui,
+                            TreeItem {
+                                index: state.node_at(item_index).index,
+                                selected: state.selected_index == item_index,
+                                response: &header_response,
+                            },
+                        );
+                    });
+                });
+            });
+
+        // State is changed after processing all rows because the item count changes and we can't simply interrupt
+        // the table widget.
+        // Once we fully implement this withouth relying on TableView, we can make this a lot better
+        if item_state_changed {
+            state.recompute_indices();
+        }
+
+        scroll_area_output
+    }
+}
+
+fn paint_tree_icon(ui: &mut egui::Ui, openness: f32, paint: bool, response: &egui::Response) {
+    let visuals = ui.style().interact(response);
+    let rect = response.rect;
+
+    // Draw a pointy triangle arrow:
+    let rect = Rect::from_center_size(rect.center(), vec2(rect.width(), rect.height()) * 0.75);
+    let rect = rect.expand(visuals.expansion);
+    if paint {
+        let mut points = vec![rect.left_top(), rect.right_top(), rect.center_bottom()];
+        use std::f32::consts::TAU;
+        let rotation = emath::Rot2::from_angle(emath::remap(openness, 0.0..=1.0, -TAU / 4.0..=0.0));
+        for p in &mut points {
+            *p = rect.center() + rotation * (*p - rect.center());
+        }
+
+        ui.painter().add(egui::Shape::convex_polygon(
+            points,
+            visuals.fg_stroke.color,
+            egui::Stroke::NONE,
+        ));
+    } else {
+        // Allocate space anyways if paint is disabled
+        ui.allocate_space(rect.size());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 mod app;
+pub mod arena;
 mod code_viewer;
 mod data_provider;
 mod data_provider_twiggy;
 mod functions_explorer;
+mod gui;
 pub use app::TemplateApp;


### PR DESCRIPTION
This PR includes two main changes:

1. Arena allocator: code is only using it for scratch buffer atm, but I intent to change `DataProviderTwiggy` to use it as well
2. Re-worked `DominatorView` to use a `Table` under the hood as opposed to collapsing headers.
  * It's a looot faster due to virtualisation (only processing views that are on screen)
  * It supports not showing the "expand/collapse" icon on symbols that don't have any children (this is also possible with collapsing header but it was a bit annoying; probably skill issues?)
  *  It requires a collapsable tree state to be represented as an array of indices (still a lot faster to update this than using collapsing headers).